### PR TITLE
dateCheck()

### DIFF
--- a/Opdracht1/src/application/App.java
+++ b/Opdracht1/src/application/App.java
@@ -1,54 +1,12 @@
 package application;
 
-import model.V2.DateGreg;;
+import model.V2.DateGreg;
+import model.V1.*;
 
 public class App {
 
 	public static void main(String[] args) throws Exception {
 
-		////////////////////// WORKING //////////////////////
-		/*
-		// All constructors OK
-		DateGreg test = new DateGreg();
-		System.out.print(test.toString() + "\n");
 		
-		DateGreg test2 = new DateGreg(27, 07, 1990);
-		System.out.print(test2.toString() + "\n");
-		
-		DateGreg test3 = new DateGreg(test);
-		System.out.print(test3.toString() + "\n");
-		
-		DateGreg test4 = new DateGreg("24/08/1998");
-		System.out.print(test4.toString() + "\n\n");
-		
-		
-		// Methods
-		System.out.print(test.getFormatAmerican() + "\n");
-		System.out.print(test.getFormatEuropean() + "\n\n");
-		
-		System.out.print(test.compareTo(test) + "\n");
-		System.out.print(test.smallerThan(test2)  + "\n\n");
-		
-		test.alterDate(-365);
-		System.out.print(test.toString() + "\n");
-		
-		test.changeDate(365);
-		System.out.print(test.toString() + "\n\n");
-		
-		System.out.print(test.compareTo(test2) + "\n\n");
-		*/
-		
-		////////////////////// NOT WORKING //////////////////////
-		
-		//System.out.print(test2.equals(test2) + "\n");
-		//System.out.print(test2.equals(test3) + "\n");
-		
-
-		//test.alterDate(aantalDagen);
-		
-		DateGreg test5 = new DateGreg(29, 02, 2016);
-		DateGreg test6 = new DateGreg("29/02/2016");
-		DateGreg test7 = new DateGreg(01,01,2016);
-		System.out.print(test5.toString() + "\n\n" + test6.toString() + "\n\n" + test7.leapTest());
 	}
 }

--- a/Opdracht1/src/application/App.java
+++ b/Opdracht1/src/application/App.java
@@ -7,6 +7,7 @@ public class App {
 
 	public static void main(String[] args) throws Exception {
 
-		
+		DateGreg test = new DateGreg(29, 02, 2016);
+		System.out.println(test.toString());
 	}
 }

--- a/Opdracht1/src/application/App.java
+++ b/Opdracht1/src/application/App.java
@@ -1,13 +1,11 @@
 package application;
 
 import model.V2.DateGreg;
-import model.V1.*;
+import model.V1.DateInt;
 
 public class App {
 
 	public static void main(String[] args) throws Exception {
-
-		DateGreg test = new DateGreg(29, 02, 2016);
-		System.out.println(test.toString());
+		
 	}
 }

--- a/Opdracht1/src/model/V1/DateInt.java
+++ b/Opdracht1/src/model/V1/DateInt.java
@@ -21,7 +21,7 @@ public class DateInt extends DateBase {
 	public DateInt() throws Exception {
 		//This is the standard constructor, nothing needs to happen here because privates have defaults of 1
 		Calendar currentDate = Calendar.getInstance();
-		this.setDate(currentDate.get(Calendar.DAY_OF_MONTH), currentDate.get(Calendar.MONTH), currentDate.get(Calendar.YEAR));
+		this.setDate(currentDate.get(Calendar.DAY_OF_MONTH), currentDate.get(Calendar.MONTH)+1, currentDate.get(Calendar.YEAR));
 	}
 	
 	public DateInt(int day, int month, int year) throws Exception {

--- a/Opdracht1/src/model/V2/DateGreg.java
+++ b/Opdracht1/src/model/V2/DateGreg.java
@@ -202,22 +202,9 @@ public class DateGreg extends DateBase {
 	 * 
 	 * @param o The object to compare this DateGreg object to
 	 */
-
+	// TODO
 	@Override
 	public int differenceInYears(Date d) throws Exception {
-		DateGreg toCompare = new DateGreg(d);
-		
-		/*
-		int diff = toCompare.Greg.get(Calendar.YEAR) - this.Greg.get(Calendar.YEAR);
-		if (this.Greg.get(Calendar.MONTH) > toCompare.Greg.get(Calendar.MONTH) ||
-				(this.Greg.get(Calendar.MONTH) == toCompare.Greg.get(Calendar.MONTH) && this.Greg.get(Calendar.DATE) > toCompare.Greg.get(Calendar.DATE))){
-			diff--;
-		}		
-		
-		return diff;
-		*/
-		
-		
 		return 0;
 	}
 
@@ -334,7 +321,7 @@ public class DateGreg extends DateBase {
 	
 	//////////////////////////////////////////////////////////////////////// HELPER ////////////////////////////////////////////////////////////////////////
 	/**
-	 * Checks if the provided date values fall within the expected parameters. If not, an error message is fetched from the MagicStrings class, and thrown as an exception.
+	 * Checks if the provided date is valid or not. If not, an error message is fetched from the MagicStrings class, and thrown as an exception.
 	 * 
 	 * @param day The provided day of the month. Should range from 1 to max. 31.
 	 * @param month The provided month. Should range from 1 to 12.
@@ -348,17 +335,8 @@ public class DateGreg extends DateBase {
 		if (year > 9999) throw new Exception(magicString.getYearRangeWrong());
 		
 		GregorianCalendar leapTest = new GregorianCalendar(year, (month-1), 1);
-		
-		System.out.println(leapTest.get(Calendar.DAY_OF_MONTH) + " " + (leapTest.get(Calendar.MONTH)+1) + " " + leapTest.get(Calendar.YEAR));
-		System.out.println("Max days? " + leapTest.getActualMaximum(Calendar.DATE));
-		
 		if (day > leapTest.getActualMaximum(Calendar.DATE)){
-			throw new Exception(String.format("The month of %1$tB counts " + leapTest.getActualMaximum(Calendar.DATE) + " days.", leapTest));
+			throw new Exception(String.format("The month of %1$tB %1$tY counts " + leapTest.getActualMaximum(Calendar.DATE) + " days.", leapTest));
 		}
-	}
-	
-	// for testing purposes
-	public Boolean leapTest() throws Exception{
-		return this.Greg.isLeapYear(this.getYear());
 	}
 }

--- a/Opdracht1/src/model/V2/DateGreg.java
+++ b/Opdracht1/src/model/V2/DateGreg.java
@@ -347,7 +347,14 @@ public class DateGreg extends DateBase {
 		if (year < 1) throw new Exception(magicString.getDateZero());
 		if (year > 9999) throw new Exception(magicString.getYearRangeWrong());
 		
-		// what about leap years? Should we let GregorianCalendar sort that out, or throw an exception?
+		GregorianCalendar leapTest = new GregorianCalendar(year, (month-1), 1);
+		
+		System.out.println(leapTest.get(Calendar.DAY_OF_MONTH) + " " + (leapTest.get(Calendar.MONTH)+1) + " " + leapTest.get(Calendar.YEAR));
+		System.out.println("Max days? " + leapTest.getActualMaximum(Calendar.DATE));
+		
+		if (day > leapTest.getActualMaximum(Calendar.DATE)){
+			throw new Exception(String.format("The month of %1$tB counts " + leapTest.getActualMaximum(Calendar.DATE) + " days.", leapTest));
+		}
 	}
 	
 	// for testing purposes

--- a/Opdracht1/src/model/V2/DateGreg.java
+++ b/Opdracht1/src/model/V2/DateGreg.java
@@ -3,26 +3,22 @@ package model.V2;
 import model.Date;
 import model.DateBase;
 import model.V1.MagicStrings;
-
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 /**
  * DateGreg is a subclass of Date, serving as a wrapper class for the GregorianCalendar class. The provided dates are to be manipulated using GregorianCalendar functions wherever possible.
- * 
- * @author André Nóbrega
- * @author Bart Janssens
  */
 public class DateGreg extends DateBase {
 	
 	// TODO difference in years/months/days
-	// TODO implement the Exception strings
 	
-	// PRIVATE VARIABLE INSTANCES //
+	//////////////////////////////////////////////////////////////////////// PRIVATE VARIABLE INSTANCES /////////////////////////////////////////////////////////////////////////
 	private GregorianCalendar Greg;
 	private MagicStrings magicString = new MagicStrings();
 	
-	// CONSTRUCTORS //
+	
+	//////////////////////////////////////////////////////////////////////// CONSTRUCTORS ////////////////////////////////////////////////////////////////////////
 	
 	/**
 	 * Instantiates a new DateGreg object using the current system time.
@@ -45,10 +41,11 @@ public class DateGreg extends DateBase {
 	 * @param month Defines the month.
 	 * @param year Defines the year.
 	 * @throws Exception
+	 * @see checkDate
 	 */
 	public DateGreg(int day, int month, int year) throws Exception{
 		checkDate(day, month, year);		
-		Greg = new GregorianCalendar(year, month, day);
+		Greg = new GregorianCalendar(year, month-1, day);
 	};
 	
 	/**
@@ -56,6 +53,8 @@ public class DateGreg extends DateBase {
 	 * 
 	 * @param date A string defining the date, in "DD/MM/YY" format.
 	 * @throws Exception Should the provided string contain formatting errors, an error message is pulled from the MagicString class.
+	 * 
+	 * @see checkDate
 	 */
 	public DateGreg(String date) throws Exception
 	{
@@ -74,7 +73,7 @@ public class DateGreg extends DateBase {
 			// Array starts with 0 index value!
 			
 			checkDate(day, month, year);
-			Greg = new GregorianCalendar(year, month, day);
+			Greg = new GregorianCalendar(year, month-1, day);
 
 		}
 		catch (Exception e){
@@ -86,7 +85,8 @@ public class DateGreg extends DateBase {
 	 * Instantiates a new DateGreg object by using an existing Date object.
 	 * 
 	 * @param date The Date object to base the new DateGregg off of.
-	 * @throws Exception Throws an exception if the provided Date cannot provide a correct string from the getFormatEuropean(); should not be technically possible.
+	 * @throws Exception Throws an exception if the provided Date cannot provide a correct string from the getFormatEuropean(); which should not be possible, since the date's already been checked and set.
+	 * @see checkDate
 	 */
 	public DateGreg(Date date) throws Exception{
 		try{
@@ -99,14 +99,15 @@ public class DateGreg extends DateBase {
 			int year = Integer.parseInt(strings[2]);
 			
 			checkDate(day, month, year);
-			Greg = new GregorianCalendar(year, month, day);
+			Greg = new GregorianCalendar(year, month-1, day);
 		}
 		catch (Exception e){
 			throw e;
 		}
 	};
 	
-	// GETTERS //
+	
+	//////////////////////////////////////////////////////////////////////// GETTERS ////////////////////////////////////////////////////////////////////////
 	/**
 	 * Provides public access to the current object's day field.
 	 * 
@@ -124,7 +125,7 @@ public class DateGreg extends DateBase {
 	 * @throws Exception
 	 */
 	public int getMonth() throws Exception{
-		return (this.Greg.get(GregorianCalendar.MONTH) + 1);
+		return (this.Greg.get(GregorianCalendar.MONTH) +1);
 	}
 	
 	/**
@@ -137,9 +138,16 @@ public class DateGreg extends DateBase {
 		return this.Greg.get(GregorianCalendar.YEAR);
 	}
 	
-	// OVERRIDES //
+	
+	//////////////////////////////////////////////////////////////////////// OVERRIDES ////////////////////////////////////////////////////////////////////////
 	/**
-	 * Changes the current object's date fields. 
+	 * Changes the current object's date fields.
+	 * 
+	 *  @param day The new date's day of the month
+	 *  @param month The new date's month
+	 *  @param year The new date's year
+	 *  @throws Exception
+	 *  @see checkDate
 	 */
 	@Override
 	public boolean setDate(int day, int month, int year) throws Exception {
@@ -173,6 +181,9 @@ public class DateGreg extends DateBase {
 
 	/**
 	 * Compares the current date object to the provided Date parameter. If the Date precedes DateGreg, this method returns a true statement.
+	 * 
+	 * @param d The date to compare this DateGreg object to
+	 * @throws Exception
 	 */
 	@Override
 	public boolean smallerThan(Date d) throws Exception {
@@ -188,17 +199,9 @@ public class DateGreg extends DateBase {
 	
 	/**
 	 * Compares the current date object to the provided Object. If both are equal, this method returns a true statement.
+	 * 
+	 * @param o The object to compare this DateGreg object to
 	 */
-	@Override
-	public boolean equals(Object o) {
-		if (this.Greg.equals(o)){
-			return true;
-		}
-		else{
-			return false;
-		}
-		// Geeft telkens een FALSE terug; ook al vergelijk je een object met zichzelf
-	}
 
 	@Override
 	public int differenceInYears(Date d) throws Exception {
@@ -218,6 +221,7 @@ public class DateGreg extends DateBase {
 		return 0;
 	}
 
+	// TODO
 	@Override
 	public int differenceInMonths(Date d) throws Exception {
 		//DateGreg toCompare = new DateGreg(d);
@@ -236,17 +240,42 @@ public class DateGreg extends DateBase {
 		
 		return 0;
 	}
-
+	
+	// TODO
 	@Override
 	public int differenceInDays(Date d) throws Exception {
 		// TODO Auto-generated method stub
 		return 0;
 	}
 
+	// TODO
 	@Override
 	public int totalDaysSinceJesus() throws Exception {
-		// TODO Auto-generated method stub
-		return 0;
+		try {
+			int total = 0;
+			int daysInMonth = this.Greg.getActualMaximum(Calendar.MONTH);
+			total += ((this.getYear() - 1) * 365);
+			
+			//calculate leapDays
+			int numberOfLeapYears = this.getYear() / 4;
+			//subtract centuries (no leapyears)
+			int numberOfCenturies = this.getYear() / 100;
+			//subtract 400's (exception on the centuries leapyears)
+			int numberOf400s = this.getYear() / 400;
+			int totalLeapDays = numberOfLeapYears - numberOfCenturies + numberOf400s;
+			
+			total += totalLeapDays;
+			
+			for (int i = 1; i < this.getMonth(); i++) {
+				total += daysInMonth;
+			}
+			
+			total += this.getDay();
+			
+			return total;
+		} catch (Exception e) {
+			throw e;
+		}
 	}
 	
 	/**
@@ -272,6 +301,7 @@ public class DateGreg extends DateBase {
 		// Geeft maand terug volgens systeemtaal 	
 	}
 
+	// TODO
 	@Override
 	public int compareTo(Date otherDate) throws Exception {
 		DateGreg toCompare = new DateGreg(otherDate);
@@ -280,26 +310,44 @@ public class DateGreg extends DateBase {
 	}
 
 	/**
+	 * Changes the current DateGreg object, by adding or subtracting a number of days to its date value. Inserting a positive integer pushes the date forward, while a negative integer subtracts from it.
 	 * 
+	 * @param numberOfDays The number of days by which the date needs to be modified.
 	 */
 	@Override
-	public void alterDate(int aantalDagen) throws Exception {
-		this.Greg.add(Calendar.DATE, aantalDagen);
+	public void alterDate(int numberOfDays) throws Exception {
+		this.Greg.add(Calendar.DATE, numberOfDays);
 	}
 
+	/**
+	 * Creates a new DateGreg object, by adding or subtracting a number of days to the current DateGreg object's date value. Inserting a positive integer pushes the date forward, while a negative integer subtracts from it.
+	 * 
+	 * @param numberOfDays The number of days by which the date needs to be modified.
+	 */
 	@Override
-	public Date changeDate(int aantalDagen) throws Exception{
+	public Date changeDate(int numberOfDays) throws Exception{
 		// TODO Check if changeDate() method gives desired result
-		this.Greg.add(Calendar.DATE, aantalDagen);
+		this.Greg.add(Calendar.DATE, numberOfDays);
 		return this;
 	}
 	
-	// HELPER
+	
+	//////////////////////////////////////////////////////////////////////// HELPER ////////////////////////////////////////////////////////////////////////
+	/**
+	 * Checks if the provided date values fall within the expected parameters. If not, an error message is fetched from the MagicStrings class, and thrown as an exception.
+	 * 
+	 * @param day The provided day of the month. Should range from 1 to max. 31.
+	 * @param month The provided month. Should range from 1 to 12.
+	 * @param year The provided year. For this application's purposes, only A.D. dates are accepted, up to the year 9999.
+	 * @throws Exception
+	 */
 	public void checkDate(int day, int month, int year) throws Exception{
 		if (day < 1 || day > 31) throw new Exception(magicString.getDayRangeWrong());
 		if (month < 1 || month > 12) throw new Exception(magicString.getMonthRangeWrong());
 		if (year < 1) throw new Exception(magicString.getDateZero());
 		if (year > 9999) throw new Exception(magicString.getYearRangeWrong());
+		
+		// what about leap years? Should we let GregorianCalendar sort that out, or throw an exception?
 	}
 	
 	// for testing purposes


### PR DESCRIPTION
-Updated documentation for DateGreg
-Added checkDate() method: invalid dates now throw exceptions instead of getting auto-corrected by GregorianCalendar (e.g.: 30/02/15 doesn't automatically become 2/03/15 anymore).
-Made minor correction to DateInt() constructor: remember that Java's Calendar uses a zero-based index for its month values (e.g.: November = 9 instead of 10)